### PR TITLE
Updates to the tutorial.md file and the README.md file

### DIFF
--- a/dataform/examples/dataform_udf_unit_test/README.md
+++ b/dataform/examples/dataform_udf_unit_test/README.md
@@ -39,13 +39,13 @@
 1. While you’re still in the example directory, copy the unit_test_utils.js file to your Dataform project directory. Then, \
    change into your newly created Dataform project directory and create your credentials file (.df-credentials.json):
    ```bash
-   cp unit_test_utils.js $DATAFORM_DIR/includes/
+   cp includes/unit_test_utils.js $DATAFORM_DIR/includes/
    cd $DATAFORM_DIR
    dataform init-creds bigquery
    ```
 1. Create a new test_cases.js  file:
    ```bash
-   echo "const {generate_udf_test} = unit_test_utils;" > $DATAFORM_DIR/definitions/test_cases.js
+   echo "const {generate_udf_test} = unit_test_utils;" > definitions/test_cases.js
    ```
 1. Add a new invocation of the generate_udf_test() function for the UDF you want to test.
    1. This function takes as arguments the string representing the name of the UDF you are going to test and an array of\

--- a/dataform/examples/dataform_udf_unit_test/tutorial.md
+++ b/dataform/examples/dataform_udf_unit_test/tutorial.md
@@ -11,26 +11,22 @@ Click the **Start** button to move to the next step.
 
 # Run the example to unit test UDFs
 
-Now that you've already downloaded the example to Cloud Shell, you're ready to install Dataform and run the commands to get this example up and running. Follow these steps to run this example:
+Now that you've already downloaded the example to Cloud Shell and you're in the example directory, you're ready to
+install Dataform and run the commands to get this example up and running. Follow these steps to run this example:
 
 ### 1. Install the Dataform CLI tool in the Cloud Shell terminal:
 ```bash
 npm i -g @dataform/cli
 ```
 
-### 2. Change into the `dataform_udf_unit_test` directory:
-```bash
-cd dataform/examples/dataform_udf_unit_test
-```
-
-### 3. Generate the Dataform credentials file by running the following:
+### 2. Generate the Dataform credentials file by running the following:
 ```bash
 dataform init-creds bigquery
 ```
 
 **Note**: You will be prompted to select your dataset location (US, EU, or other), whether you would like to use Application Default Credentials (**recommended**) or a JSON key, and your billing project ID. Dataform will generate a file called `.df-credentials.json` that will contain your BigQuery project ID and the geographic location in which queries will run.
 
-### 4. Execute the unit tests by running the following Dataform command:
+### 3. Execute the unit tests by running the following Dataform command:
 ```bash
 dataform test
 ```
@@ -57,7 +53,7 @@ dataform init bigquery $DATAFORM_DIR --default-database $PROJECT_ID
 
 ### 3. While you’re still in the example directory, copy the `unit_test_utils.js` file to your Dataform project directory and change into your newly created Dataform project directory:
 ```bash
-cp unit_test_utils.js $DATAFORM_DIR/includes/
+cp includes/unit_test_utils.js $DATAFORM_DIR/includes/
 cd $DATAFORM_DIR
 ```
 
@@ -68,11 +64,19 @@ dataform init-creds bigquery
 
 ### 5. Create a new `test_cases.js` file:
 ```bash
-echo "const {generate_udf_test} = unit_test_utils;" > $DATAFORM_DIR/definitions/test_cases.js
+echo "const {generate_udf_test} = unit_test_utils;" > definitions/test_cases.js
 ```
 **Note**: This is the main file you'll be editing. You will be supplying the input(s) and expected outputs of your UDFs in this file.
 
 ### 6. Add a new invocation of the generate_udf_test() function for the UDF you want to test:
+
+```
+<walkthrough-editor-open-file
+    filePath="definitions/test_cases.js">
+    open the test_cases.js file to edit it
+</walkthrough-editor-open-file>
+```
+
 ```
 generate_udf_test("YOUR_UDF_NAME", [  
       { // JS Object for test case #1

--- a/dataform/examples/dataform_udf_unit_test/tutorial.md
+++ b/dataform/examples/dataform_udf_unit_test/tutorial.md
@@ -9,7 +9,7 @@ how to unit test your own UDFs.
 
 Click the **Start** button to move to the next step.
 
-# Run the example to unit test UDFs
+## Run the example to unit test UDFs
 
 Now that you've already downloaded the example to Cloud Shell and you're in the example directory, you're ready to
 install Dataform and run the commands to get this example up and running. Follow these steps to run this example:
@@ -35,7 +35,7 @@ Congratulations, you successfully ran the example!
 
 To learn how to modify this example to unit test your own UDFs, click **Next**.
 
-# Run Your Own UDF Unit Tests
+## Run Your Own UDF Unit Tests
 
 ### 1. Create environment variables for the path to your Dataform directory and your BigQuery project ID:
 Dataform project using these environment variables:
@@ -70,12 +70,10 @@ echo "const {generate_udf_test} = unit_test_utils;" > definitions/test_cases.js
 
 ### 6. Add a new invocation of the generate_udf_test() function for the UDF you want to test:
 
-```
 <walkthrough-editor-open-file
     filePath="definitions/test_cases.js">
-    open the test_cases.js file to edit it
+    open the test_cases.js file here to edit it
 </walkthrough-editor-open-file>
-```
 
 ```
 generate_udf_test("YOUR_UDF_NAME", [  


### PR DESCRIPTION
made changes to the paths that were used in these files, included a directive to open the test_cases.js file in tutorial.md, and removed an unnecessary step to change directory under the section to run the example